### PR TITLE
Generate code samples for new Verify domain

### DIFF
--- a/verify/v1/service/create-default/create-default.3.x.js
+++ b/verify/v1/service/create-default/create-default.3.x.js
@@ -1,0 +1,9 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services.create({friendlyName: 'friendlyName'})
+                      .then(service => console.log(service.sid))
+                      .done();

--- a/verify/v1/service/create-default/create-default.5.x.cs
+++ b/verify/v1/service/create-default/create-default.5.x.cs
@@ -1,0 +1,22 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V1;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var service = ServiceResource.Create(friendlyName: "FriendlyName");
+
+        Console.WriteLine(service.Sid);
+    }
+}

--- a/verify/v1/service/create-default/create-default.5.x.php
+++ b/verify/v1/service/create-default/create-default.5.x.php
@@ -1,0 +1,17 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$service = $twilio->verify->v1->services
+                              ->create("friendlyName");
+
+print($service->sid);

--- a/verify/v1/service/create-default/create-default.5.x.rb
+++ b/verify/v1/service/create-default/create-default.5.x.rb
@@ -1,0 +1,12 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+service = @client.verify.services.create(friendly_name: 'friendly_name')
+
+puts service.sid

--- a/verify/v1/service/create-default/create-default.6.x.py
+++ b/verify/v1/service/create-default/create-default.6.x.py
@@ -1,0 +1,12 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+service = client.verify.services.create(friendly_name='friendly_name')
+
+print(service.sid)

--- a/verify/v1/service/create-default/create-default.7.x.java
+++ b/verify/v1/service/create-default/create-default.7.x.java
@@ -1,0 +1,17 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v1.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Service service = Service.creator("friendlyName").create();
+
+        System.out.println(service.getSid());
+    }
+}

--- a/verify/v1/service/create-default/create-default.json.curl
+++ b/verify/v1/service/create-default/create-default.json.curl
@@ -1,0 +1,3 @@
+curl -X POST https://verify.twilio.com/v1/Services \
+--data-urlencode "FriendlyName=FriendlyName" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v1/service/create-default/meta.json
+++ b/verify/v1/service/create-default/meta.json
@@ -1,0 +1,16 @@
+{
+  "type": "server",
+  "title": "Create Service",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v1/Services",
+    "method": "post",
+    "domain": "verify",
+    "version": "v1",
+    "resource": "service",
+    "action": "create"
+  }
+}

--- a/verify/v1/service/create-default/output/create-default.json
+++ b/verify/v1/service/create-default/output/create-default.json
@@ -1,0 +1,13 @@
+{
+  "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "friendly_name": "name",
+  "code_length": 4,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "url": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "links": {
+    "verification_checks": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+    "verifications": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+  }
+}

--- a/verify/v1/service/fetch-default/fetch-default.3.x.js
+++ b/verify/v1/service/fetch-default/fetch-default.3.x.js
@@ -1,0 +1,10 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .fetch()
+             .then(service => console.log(service.friendlyName))
+             .done();

--- a/verify/v1/service/fetch-default/fetch-default.5.x.cs
+++ b/verify/v1/service/fetch-default/fetch-default.5.x.cs
@@ -1,0 +1,22 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V1;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var service = ServiceResource.Fetch(pathSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+
+        Console.WriteLine(service.FriendlyName);
+    }
+}

--- a/verify/v1/service/fetch-default/fetch-default.5.x.php
+++ b/verify/v1/service/fetch-default/fetch-default.5.x.php
@@ -1,0 +1,17 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$service = $twilio->verify->v1->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                              ->fetch();
+
+print($service->friendlyName);

--- a/verify/v1/service/fetch-default/fetch-default.5.x.rb
+++ b/verify/v1/service/fetch-default/fetch-default.5.x.rb
@@ -1,0 +1,12 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+service = @client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').fetch
+
+puts service.friendly_name

--- a/verify/v1/service/fetch-default/fetch-default.6.x.py
+++ b/verify/v1/service/fetch-default/fetch-default.6.x.py
@@ -1,0 +1,12 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+service = client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').fetch()
+
+print(service.friendly_name)

--- a/verify/v1/service/fetch-default/fetch-default.7.x.java
+++ b/verify/v1/service/fetch-default/fetch-default.7.x.java
@@ -1,0 +1,18 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v1.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Service service = Service.fetcher("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+            .fetch();
+
+        System.out.println(service.getFriendlyName());
+    }
+}

--- a/verify/v1/service/fetch-default/fetch-default.json.curl
+++ b/verify/v1/service/fetch-default/fetch-default.json.curl
@@ -1,0 +1,2 @@
+curl -X GET 'https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v1/service/fetch-default/meta.json
+++ b/verify/v1/service/fetch-default/meta.json
@@ -1,0 +1,16 @@
+{
+  "type": "server",
+  "title": "Fetch Service",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v1/Services/{sid}",
+    "method": "get",
+    "domain": "verify",
+    "version": "v1",
+    "resource": "service",
+    "action": "fetch"
+  }
+}

--- a/verify/v1/service/fetch-default/output/fetch-default.json
+++ b/verify/v1/service/fetch-default/output/fetch-default.json
@@ -1,0 +1,13 @@
+{
+  "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "friendly_name": "name",
+  "code_length": 4,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "url": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "links": {
+    "verification_checks": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+    "verifications": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+  }
+}

--- a/verify/v1/service/read-default/meta.json
+++ b/verify/v1/service/read-default/meta.json
@@ -1,0 +1,16 @@
+{
+  "type": "server",
+  "title": "Read Service",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v1/Services",
+    "method": "get",
+    "domain": "verify",
+    "version": "v1",
+    "resource": "service",
+    "action": "read"
+  }
+}

--- a/verify/v1/service/read-default/output/read-default.json
+++ b/verify/v1/service/read-default/output/read-default.json
@@ -1,0 +1,26 @@
+{
+  "meta": {
+    "page": 0,
+    "page_size": 50,
+    "first_page_url": "https://verify.twilio.com/v1/Services?PageSize=50&Page=0",
+    "previous_page_url": "https://verify.twilio.com/v1/Services?PageSize=50&Page=0",
+    "next_page_url": "https://verify.twilio.com/v1/Services?PageSize=50&Page=1",
+    "key": "services",
+    "url": "https://verify.twilio.com/v1/Services?PageSize=50&Page=0"
+  },
+  "services": [
+    {
+      "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "friendly_name": "name",
+      "code_length": 4,
+      "date_created": "2015-07-30T20:00:00Z",
+      "date_updated": "2015-07-30T20:00:00Z",
+      "url": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "links": {
+        "verification_checks": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+        "verifications": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+      }
+    }
+  ]
+}

--- a/verify/v1/service/read-default/read-default.3.x.js
+++ b/verify/v1/service/read-default/read-default.3.x.js
@@ -1,0 +1,7 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services.each(services => console.log(services.sid));

--- a/verify/v1/service/read-default/read-default.5.x.cs
+++ b/verify/v1/service/read-default/read-default.5.x.cs
@@ -1,0 +1,25 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V1;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var services = ServiceResource.Read();
+
+        foreach(var record in services)
+        {
+           Console.WriteLine(record.Sid);
+        }
+    }
+}

--- a/verify/v1/service/read-default/read-default.5.x.php
+++ b/verify/v1/service/read-default/read-default.5.x.php
@@ -1,0 +1,19 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$services = $twilio->verify->v1->services
+                               ->read();
+
+foreach ($services as $record) {
+    print($record->sid);
+}

--- a/verify/v1/service/read-default/read-default.5.x.rb
+++ b/verify/v1/service/read-default/read-default.5.x.rb
@@ -1,0 +1,14 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+services = @client.verify.services.list
+
+services.each do |record|
+  puts record.sid
+end

--- a/verify/v1/service/read-default/read-default.6.x.py
+++ b/verify/v1/service/read-default/read-default.6.x.py
@@ -1,0 +1,13 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+services = client.verify.services.list()
+
+for record in services:
+    print(record.sid)

--- a/verify/v1/service/read-default/read-default.7.x.java
+++ b/verify/v1/service/read-default/read-default.7.x.java
@@ -1,0 +1,20 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.base.ResourceSet;
+import com.twilio.rest.verify.v1.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        ResourceSet<Service> services = Service.reader().read();
+
+        for(Service record : services) {
+            System.out.println(record.getSid());
+        }
+    }
+}

--- a/verify/v1/service/read-default/read-default.json.curl
+++ b/verify/v1/service/read-default/read-default.json.curl
@@ -1,0 +1,2 @@
+curl -X GET 'https://verify.twilio.com/v1/Services' \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v1/service/update-default/meta.json
+++ b/verify/v1/service/update-default/meta.json
@@ -1,0 +1,16 @@
+{
+  "type": "server",
+  "title": "Update Service",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v1/Services/{sid}",
+    "method": "post",
+    "domain": "verify",
+    "version": "v1",
+    "resource": "service",
+    "action": "update"
+  }
+}

--- a/verify/v1/service/update-default/output/update-default.json
+++ b/verify/v1/service/update-default/output/update-default.json
@@ -1,0 +1,13 @@
+{
+  "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "friendly_name": "name",
+  "code_length": 4,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "url": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "links": {
+    "verification_checks": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+    "verifications": "https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+  }
+}

--- a/verify/v1/service/update-default/update-default.3.x.js
+++ b/verify/v1/service/update-default/update-default.3.x.js
@@ -1,0 +1,10 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .update({friendlyName: 'friendlyName'})
+             .then(service => console.log(service.friendlyName))
+             .done();

--- a/verify/v1/service/update-default/update-default.5.x.cs
+++ b/verify/v1/service/update-default/update-default.5.x.cs
@@ -1,0 +1,25 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V1;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var service = ServiceResource.Update(
+            friendlyName: "FriendlyName",
+            pathSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        );
+
+        Console.WriteLine(service.FriendlyName);
+    }
+}

--- a/verify/v1/service/update-default/update-default.5.x.php
+++ b/verify/v1/service/update-default/update-default.5.x.php
@@ -1,0 +1,17 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$service = $twilio->verify->v1->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                              ->update(array("friendlyName" => "friendlyName"));
+
+print($service->friendlyName);

--- a/verify/v1/service/update-default/update-default.5.x.rb
+++ b/verify/v1/service/update-default/update-default.5.x.rb
@@ -1,0 +1,13 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+service = @client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                        .update(friendly_name: 'friendly_name')
+
+puts service.friendly_name

--- a/verify/v1/service/update-default/update-default.6.x.py
+++ b/verify/v1/service/update-default/update-default.6.x.py
@@ -1,0 +1,13 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+service = client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                       .update(friendly_name='friendly_name')
+
+print(service.friendly_name)

--- a/verify/v1/service/update-default/update-default.7.x.java
+++ b/verify/v1/service/update-default/update-default.7.x.java
@@ -1,0 +1,18 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v1.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Service service = Service.updater("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+            .setFriendlyName("friendlyName").update();
+
+        System.out.println(service.getFriendlyName());
+    }
+}

--- a/verify/v1/service/update-default/update-default.json.curl
+++ b/verify/v1/service/update-default/update-default.json.curl
@@ -1,0 +1,3 @@
+curl -X POST https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+--data-urlencode "FriendlyName=FriendlyName" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v1/verification/create-default/create-default.3.x.js
+++ b/verify/v1/verification/create-default/create-default.3.x.js
@@ -1,0 +1,11 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .verifications
+             .create({to: 'to', channel: 'channel'})
+             .then(verification => console.log(verification.sid))
+             .done();

--- a/verify/v1/verification/create-default/create-default.5.x.cs
+++ b/verify/v1/verification/create-default/create-default.5.x.cs
@@ -1,0 +1,26 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V1.Service;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var verification = VerificationResource.Create(
+            to: "To",
+            channel: "Channel",
+            pathServiceSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        );
+
+        Console.WriteLine(verification.Sid);
+    }
+}

--- a/verify/v1/verification/create-default/create-default.5.x.php
+++ b/verify/v1/verification/create-default/create-default.5.x.php
@@ -1,0 +1,18 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$verification = $twilio->verify->v1->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                   ->verifications
+                                   ->create("to", "channel");
+
+print($verification->sid);

--- a/verify/v1/verification/create-default/create-default.5.x.rb
+++ b/verify/v1/verification/create-default/create-default.5.x.rb
@@ -1,0 +1,15 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+verification = @client.verify
+                      .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                      .verifications
+                      .create(to: 'to', channel: 'channel')
+
+puts verification.sid

--- a/verify/v1/verification/create-default/create-default.6.x.py
+++ b/verify/v1/verification/create-default/create-default.6.x.py
@@ -1,0 +1,15 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+verification = client.verify \
+                     .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                     .verifications \
+                     .create(to='to', channel='channel')
+
+print(verification.sid)

--- a/verify/v1/verification/create-default/create-default.7.x.java
+++ b/verify/v1/verification/create-default/create-default.7.x.java
@@ -1,0 +1,21 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v1.service.Verification;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Verification verification = Verification.creator(
+                "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "to",
+                "channel")
+            .create();
+
+        System.out.println(verification.getSid());
+    }
+}

--- a/verify/v1/verification/create-default/create-default.json.curl
+++ b/verify/v1/verification/create-default/create-default.json.curl
@@ -1,0 +1,4 @@
+curl -X POST https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications \
+--data-urlencode "To=To" \
+--data-urlencode "Channel=Channel" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v1/verification/create-default/meta.json
+++ b/verify/v1/verification/create-default/meta.json
@@ -1,0 +1,16 @@
+{
+  "type": "server",
+  "title": "Create Verification",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v1/Services/{service_sid}/Verifications",
+    "method": "post",
+    "domain": "verify",
+    "version": "v1",
+    "resource": "verification",
+    "action": "create"
+  }
+}

--- a/verify/v1/verification/create-default/output/create-default.json
+++ b/verify/v1/verification/create-default/output/create-default.json
@@ -1,0 +1,11 @@
+{
+  "sid": "VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+14159373912",
+  "channel": "sms",
+  "status": "pending",
+  "valid": null,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z"
+}

--- a/verify/v1/verification_check/create-default/create-default.3.x.js
+++ b/verify/v1/verification_check/create-default/create-default.3.x.js
@@ -1,0 +1,11 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .verificationChecks
+             .create({code: 'code'})
+             .then(verification_check => console.log(verification_check.sid))
+             .done();

--- a/verify/v1/verification_check/create-default/create-default.5.x.cs
+++ b/verify/v1/verification_check/create-default/create-default.5.x.cs
@@ -1,0 +1,25 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V1.Service;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var verificationCheck = VerificationCheckResource.Create(
+            code: "Code",
+            pathServiceSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        );
+
+        Console.WriteLine(verificationCheck.Sid);
+    }
+}

--- a/verify/v1/verification_check/create-default/create-default.5.x.php
+++ b/verify/v1/verification_check/create-default/create-default.5.x.php
@@ -1,0 +1,18 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$verification_check = $twilio->verify->v1->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                         ->verificationChecks
+                                         ->create("code");
+
+print($verification_check->sid);

--- a/verify/v1/verification_check/create-default/create-default.5.x.rb
+++ b/verify/v1/verification_check/create-default/create-default.5.x.rb
@@ -1,0 +1,15 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+verification_check = @client.verify
+                            .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                            .verification_checks
+                            .create(code: 'code')
+
+puts verification_check.sid

--- a/verify/v1/verification_check/create-default/create-default.6.x.py
+++ b/verify/v1/verification_check/create-default/create-default.6.x.py
@@ -1,0 +1,15 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+verification_check = client.verify \
+                           .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                           .verification_checks \
+                           .create(code='code')
+
+print(verification_check.sid)

--- a/verify/v1/verification_check/create-default/create-default.7.x.java
+++ b/verify/v1/verification_check/create-default/create-default.7.x.java
@@ -1,0 +1,20 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v1.service.VerificationCheck;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        VerificationCheck verificationCheck = VerificationCheck.creator(
+                "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "code")
+            .create();
+
+        System.out.println(verificationCheck.getSid());
+    }
+}

--- a/verify/v1/verification_check/create-default/create-default.json.curl
+++ b/verify/v1/verification_check/create-default/create-default.json.curl
@@ -1,0 +1,3 @@
+curl -X POST https://verify.twilio.com/v1/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck \
+--data-urlencode "Code=Code" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v1/verification_check/create-default/meta.json
+++ b/verify/v1/verification_check/create-default/meta.json
@@ -1,0 +1,16 @@
+{
+  "type": "server",
+  "title": "Create Verification Check",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v1/Services/{service_sid}/VerificationCheck",
+    "method": "post",
+    "domain": "verify",
+    "version": "v1",
+    "resource": "verification_check",
+    "action": "create"
+  }
+}

--- a/verify/v1/verification_check/create-default/output/create-default.json
+++ b/verify/v1/verification_check/create-default/output/create-default.json
@@ -1,0 +1,12 @@
+{
+  "sid": "VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+14159373912",
+  "channel": "sms",
+  "status": "approved",
+  "valid": false,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "code": null
+}


### PR DESCRIPTION
Verify recently made the move from `preview.acc_security` to `verify.v1`

Generated samples for the new domain. Will need to determine if we should delete the existing/old samples in `preview.acc_security` yet.