### PR TITLE
Update from value in copilot sms request

### DIFF
--- a/api/v2010/message/create-send-messages-copilot/output/create-send-messages-copilot.json
+++ b/api/v2010/message/create-send-messages-copilot/output/create-send-messages-copilot.json
@@ -8,7 +8,7 @@
   "direction": "outbound-api",
   "error_code": null,
   "error_message": null,
-  "from": "+14155552345",
+  "from": null,
   "messaging_service_sid": "MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "num_media": "0",
   "num_segments": "1",


### PR DESCRIPTION
Copilot selects the number to send from asynchronously, so we don’t have that information at request time. Looks like somebody on the product team needs to make a change, but it's a good thing to know!
