### PR TITLE
Add PSD2 samples, remove PSD2 fields from default samples

### DIFF
--- a/verify/v2/service/create-default/create-default.3.x.js
+++ b/verify/v2/service/create-default/create-default.3.x.js
@@ -1,0 +1,9 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services.create({friendlyName: 'FriendlyName'})
+                      .then(service => console.log(service.sid));

--- a/verify/v2/service/create-default/create-default.5.x.cs
+++ b/verify/v2/service/create-default/create-default.5.x.cs
@@ -1,0 +1,23 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var service = ServiceResource.Create(friendlyName: "FriendlyName");
+
+        Console.WriteLine(service.Sid);
+    }
+}

--- a/verify/v2/service/create-default/create-default.5.x.php
+++ b/verify/v2/service/create-default/create-default.5.x.php
@@ -1,0 +1,18 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$service = $twilio->verify->v2->services
+                              ->create("FriendlyName");
+
+print($service->sid);

--- a/verify/v2/service/create-default/create-default.5.x.rb
+++ b/verify/v2/service/create-default/create-default.5.x.rb
@@ -1,0 +1,13 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+service = @client.verify.services.create(friendly_name: 'FriendlyName')
+
+puts service.sid

--- a/verify/v2/service/create-default/create-default.6.x.py
+++ b/verify/v2/service/create-default/create-default.6.x.py
@@ -1,0 +1,13 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+service = client.verify.services.create(friendly_name='FriendlyName')
+
+print(service.sid)

--- a/verify/v2/service/create-default/create-default.7.x.java
+++ b/verify/v2/service/create-default/create-default.7.x.java
@@ -1,0 +1,18 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Service service = Service.creator("FriendlyName").create();
+
+        System.out.println(service.getSid());
+    }
+}

--- a/verify/v2/service/create-default/create-default.json.curl
+++ b/verify/v2/service/create-default/create-default.json.curl
@@ -1,0 +1,3 @@
+curl -X POST https://verify.twilio.com/v2/Services \
+--data-urlencode "FriendlyName=FriendlyName" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/service/create-default/meta.json
+++ b/verify/v2/service/create-default/meta.json
@@ -1,0 +1,18 @@
+{
+  "type": "server",
+  "title": "Create Service",
+  "_definition": {
+    "params": {
+      "required": {
+        "friendly_name": "FriendlyName"
+      },
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v2/Services",
+    "method": "post",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "service",
+    "action": "create"
+  }
+}

--- a/verify/v2/service/create-default/output/create-default.json
+++ b/verify/v2/service/create-default/output/create-default.json
@@ -1,0 +1,18 @@
+{
+  "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "friendly_name": "FriendlyName",
+  "code_length": 4,
+  "lookup_enabled": false,
+  "psd2_enabled": false,
+  "skip_sms_to_landlines": false,
+  "dtmf_input_required": false,
+  "tts_name": "name",
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "links": {
+    "verification_checks": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+    "verifications": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+  }
+}

--- a/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.3.x.js
+++ b/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.3.x.js
@@ -1,0 +1,13 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services
+             .create({
+                psd2Enabled: true,
+                friendlyName: 'My PSD2 Compliant Service'
+              })
+             .then(service => console.log(service.sid));

--- a/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.5.x.cs
+++ b/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.5.x.cs
@@ -1,0 +1,26 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var service = ServiceResource.Create(
+            psd2Enabled: true,
+            friendlyName: "My PSD2 Compliant Service"
+        );
+
+        Console.WriteLine(service.Sid);
+    }
+}

--- a/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.5.x.php
+++ b/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.5.x.php
@@ -1,0 +1,20 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$service = $twilio->verify->v2->services
+                              ->create("My PSD2 Compliant Service", // friendlyName
+                                       array("psd2Enabled" => True)
+                              );
+
+print($service->sid);

--- a/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.5.x.rb
+++ b/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.5.x.rb
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+service = @client.verify.services.create(
+                                    psd2_enabled: true,
+                                    friendly_name: 'My PSD2 Compliant Service'
+                                  )
+
+puts service.sid

--- a/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.6.x.py
+++ b/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.6.x.py
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+service = client.verify.services.create(
+                                     psd2_enabled=True,
+                                     friendly_name='My PSD2 Compliant Service'
+                                 )
+
+print(service.sid)

--- a/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.7.x.java
+++ b/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.7.x.java
@@ -1,0 +1,19 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Service service = Service.creator("My PSD2 Compliant Service")
+            .setPsd2Enabled(true).create();
+
+        System.out.println(service.getSid());
+    }
+}

--- a/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.json.curl
+++ b/verify/v2/service/create-psd2_enabled_service/create-psd2_enabled_service.json.curl
@@ -1,0 +1,4 @@
+curl -X POST https://verify.twilio.com/v2/Services \
+--data-urlencode "Psd2Enabled=True" \
+--data-urlencode "FriendlyName=My PSD2 Compliant Service" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/service/create-psd2_enabled_service/meta.json
+++ b/verify/v2/service/create-psd2_enabled_service/meta.json
@@ -1,0 +1,20 @@
+{
+  "title": "Create a PSD2 Enabled Verify Service",
+  "type": "server",
+  "transaction_name": "create_psd2_enabled_service",
+  "_definition": {
+    "params": {
+      "required": {
+        "psd2_enabled": true,
+        "friendly_name": "My PSD2 Compliant Service"
+      },
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v2/Services",
+    "method": "post",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "service",
+    "action": "create"
+  }
+}

--- a/verify/v2/service/create-psd2_enabled_service/output/create-psd2_enabled_service.json
+++ b/verify/v2/service/create-psd2_enabled_service/output/create-psd2_enabled_service.json
@@ -1,0 +1,18 @@
+{
+  "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "friendly_name": "My PSD2 Compliant Service",
+  "code_length": 4,
+  "lookup_enabled": false,
+  "psd2_enabled": true,
+  "skip_sms_to_landlines": false,
+  "dtmf_input_required": false,
+  "tts_name": "name",
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "links": {
+    "verification_checks": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+    "verifications": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+  }
+}

--- a/verify/v2/service/delete-default/delete-default.3.x.js
+++ b/verify/v2/service/delete-default/delete-default.3.x.js
@@ -1,0 +1,10 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .remove()
+             .then(service => console.log(service.sid));

--- a/verify/v2/service/delete-default/delete-default.5.x.cs
+++ b/verify/v2/service/delete-default/delete-default.5.x.cs
@@ -1,0 +1,21 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        ServiceResource.Delete(pathSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+    }
+}

--- a/verify/v2/service/delete-default/delete-default.5.x.php
+++ b/verify/v2/service/delete-default/delete-default.5.x.php
@@ -1,0 +1,16 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                   ->delete();

--- a/verify/v2/service/delete-default/delete-default.5.x.rb
+++ b/verify/v2/service/delete-default/delete-default.5.x.rb
@@ -1,0 +1,11 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+@client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').delete

--- a/verify/v2/service/delete-default/delete-default.6.x.py
+++ b/verify/v2/service/delete-default/delete-default.6.x.py
@@ -1,0 +1,11 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').delete()

--- a/verify/v2/service/delete-default/delete-default.7.x.java
+++ b/verify/v2/service/delete-default/delete-default.7.x.java
@@ -1,0 +1,16 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Service.deleter("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX").delete();
+    }
+}

--- a/verify/v2/service/delete-default/delete-default.json.curl
+++ b/verify/v2/service/delete-default/delete-default.json.curl
@@ -1,0 +1,2 @@
+curl -X DELETE https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/service/delete-default/meta.json
+++ b/verify/v2/service/delete-default/meta.json
@@ -1,0 +1,18 @@
+{
+  "type": "server",
+  "title": "Delete Service",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {
+        "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{sid}",
+    "method": "delete",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "service",
+    "action": "delete"
+  }
+}

--- a/verify/v2/service/fetch-default/fetch-default.3.x.js
+++ b/verify/v2/service/fetch-default/fetch-default.3.x.js
@@ -1,0 +1,10 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .fetch()
+             .then(service => console.log(service.friendlyName));

--- a/verify/v2/service/fetch-default/fetch-default.5.x.cs
+++ b/verify/v2/service/fetch-default/fetch-default.5.x.cs
@@ -1,0 +1,23 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var service = ServiceResource.Fetch(pathSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+
+        Console.WriteLine(service.FriendlyName);
+    }
+}

--- a/verify/v2/service/fetch-default/fetch-default.5.x.php
+++ b/verify/v2/service/fetch-default/fetch-default.5.x.php
@@ -1,0 +1,18 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$service = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                              ->fetch();
+
+print($service->friendlyName);

--- a/verify/v2/service/fetch-default/fetch-default.5.x.rb
+++ b/verify/v2/service/fetch-default/fetch-default.5.x.rb
@@ -1,0 +1,13 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+service = @client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').fetch
+
+puts service.friendly_name

--- a/verify/v2/service/fetch-default/fetch-default.6.x.py
+++ b/verify/v2/service/fetch-default/fetch-default.6.x.py
@@ -1,0 +1,13 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+service = client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX').fetch()
+
+print(service.friendly_name)

--- a/verify/v2/service/fetch-default/fetch-default.7.x.java
+++ b/verify/v2/service/fetch-default/fetch-default.7.x.java
@@ -1,0 +1,19 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Service service = Service.fetcher("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+            .fetch();
+
+        System.out.println(service.getFriendlyName());
+    }
+}

--- a/verify/v2/service/fetch-default/fetch-default.json.curl
+++ b/verify/v2/service/fetch-default/fetch-default.json.curl
@@ -1,0 +1,2 @@
+curl -X GET 'https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/service/fetch-default/meta.json
+++ b/verify/v2/service/fetch-default/meta.json
@@ -1,0 +1,18 @@
+{
+  "type": "server",
+  "title": "Fetch Service",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {
+        "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{sid}",
+    "method": "get",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "service",
+    "action": "fetch"
+  }
+}

--- a/verify/v2/service/fetch-default/output/fetch-default.json
+++ b/verify/v2/service/fetch-default/output/fetch-default.json
@@ -1,0 +1,18 @@
+{
+  "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "friendly_name": "name",
+  "code_length": 4,
+  "lookup_enabled": false,
+  "psd2_enabled": false,
+  "skip_sms_to_landlines": false,
+  "dtmf_input_required": false,
+  "tts_name": "name",
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "links": {
+    "verification_checks": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+    "verifications": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+  }
+}

--- a/verify/v2/service/read-default/meta.json
+++ b/verify/v2/service/read-default/meta.json
@@ -1,0 +1,16 @@
+{
+  "type": "server",
+  "title": "Read Service",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {}
+    },
+    "location": "https://verify.twilio.com/v2/Services",
+    "method": "get",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "service",
+    "action": "read"
+  }
+}

--- a/verify/v2/service/read-default/output/read-default.json
+++ b/verify/v2/service/read-default/output/read-default.json
@@ -1,0 +1,31 @@
+{
+  "meta": {
+    "page": 0,
+    "page_size": 50,
+    "first_page_url": "https://verify.twilio.com/v2/Services?PageSize=50&Page=0",
+    "previous_page_url": "https://verify.twilio.com/v2/Services?PageSize=50&Page=0",
+    "next_page_url": "https://verify.twilio.com/v2/Services?PageSize=50&Page=1",
+    "key": "services",
+    "url": "https://verify.twilio.com/v2/Services?PageSize=50&Page=0"
+  },
+  "services": [
+    {
+      "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "friendly_name": "name",
+      "code_length": 4,
+      "lookup_enabled": false,
+      "psd2_enabled": false,
+      "skip_sms_to_landlines": false,
+      "dtmf_input_required": false,
+      "tts_name": "name",
+      "date_created": "2015-07-30T20:00:00Z",
+      "date_updated": "2015-07-30T20:00:00Z",
+      "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "links": {
+        "verification_checks": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+        "verifications": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+      }
+    }
+  ]
+}

--- a/verify/v2/service/read-default/read-default.3.x.js
+++ b/verify/v2/service/read-default/read-default.3.x.js
@@ -1,0 +1,8 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services.each(services => console.log(services.sid));

--- a/verify/v2/service/read-default/read-default.5.x.cs
+++ b/verify/v2/service/read-default/read-default.5.x.cs
@@ -1,0 +1,26 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var services = ServiceResource.Read();
+
+        foreach(var record in services)
+        {
+           Console.WriteLine(record.Sid);
+        }
+    }
+}

--- a/verify/v2/service/read-default/read-default.5.x.php
+++ b/verify/v2/service/read-default/read-default.5.x.php
@@ -1,0 +1,20 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$services = $twilio->verify->v2->services
+                               ->read();
+
+foreach ($services as $record) {
+    print($record->sid);
+}

--- a/verify/v2/service/read-default/read-default.5.x.rb
+++ b/verify/v2/service/read-default/read-default.5.x.rb
@@ -1,0 +1,15 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+services = @client.verify.services.list
+
+services.each do |record|
+  puts record.sid
+end

--- a/verify/v2/service/read-default/read-default.6.x.py
+++ b/verify/v2/service/read-default/read-default.6.x.py
@@ -1,0 +1,14 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+services = client.verify.services.list()
+
+for record in services:
+    print(record.sid)

--- a/verify/v2/service/read-default/read-default.7.x.java
+++ b/verify/v2/service/read-default/read-default.7.x.java
@@ -1,0 +1,21 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.base.ResourceSet;
+import com.twilio.rest.verify.v2.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        ResourceSet<Service> services = Service.reader().read();
+
+        for(Service record : services) {
+            System.out.println(record.getSid());
+        }
+    }
+}

--- a/verify/v2/service/read-default/read-default.json.curl
+++ b/verify/v2/service/read-default/read-default.json.curl
@@ -1,0 +1,2 @@
+curl -X GET 'https://verify.twilio.com/v2/Services' \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/service/update-default/meta.json
+++ b/verify/v2/service/update-default/meta.json
@@ -1,0 +1,20 @@
+{
+  "type": "server",
+  "title": "Update Service",
+  "_definition": {
+    "params": {
+      "required": {
+        "friendly_name": "friendly_name"
+      },
+      "path": {
+        "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{sid}",
+    "method": "post",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "service",
+    "action": "update"
+  }
+}

--- a/verify/v2/service/update-default/output/update-default.json
+++ b/verify/v2/service/update-default/output/update-default.json
@@ -1,0 +1,18 @@
+{
+  "sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "friendly_name": "name",
+  "code_length": 4,
+  "lookup_enabled": false,
+  "psd2_enabled": false,
+  "skip_sms_to_landlines": false,
+  "dtmf_input_required": false,
+  "tts_name": "name",
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "links": {
+    "verification_checks": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck",
+    "verifications": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications"
+  }
+}

--- a/verify/v2/service/update-default/update-default.3.x.js
+++ b/verify/v2/service/update-default/update-default.3.x.js
@@ -1,0 +1,10 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .update({friendlyName: 'friendlyName'})
+             .then(service => console.log(service.friendlyName));

--- a/verify/v2/service/update-default/update-default.5.x.cs
+++ b/verify/v2/service/update-default/update-default.5.x.cs
@@ -1,0 +1,26 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var service = ServiceResource.Update(
+            friendlyName: "friendlyName",
+            pathSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        );
+
+        Console.WriteLine(service.FriendlyName);
+    }
+}

--- a/verify/v2/service/update-default/update-default.5.x.php
+++ b/verify/v2/service/update-default/update-default.5.x.php
@@ -1,0 +1,18 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$service = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                              ->update(array("friendlyName" => "friendlyName"));
+
+print($service->friendlyName);

--- a/verify/v2/service/update-default/update-default.5.x.rb
+++ b/verify/v2/service/update-default/update-default.5.x.rb
@@ -1,0 +1,14 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+service = @client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                        .update(friendly_name: 'friendly_name')
+
+puts service.friendly_name

--- a/verify/v2/service/update-default/update-default.6.x.py
+++ b/verify/v2/service/update-default/update-default.6.x.py
@@ -1,0 +1,14 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+service = client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                       .update(friendly_name='friendly_name')
+
+print(service.friendly_name)

--- a/verify/v2/service/update-default/update-default.7.x.java
+++ b/verify/v2/service/update-default/update-default.7.x.java
@@ -1,0 +1,19 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.Service;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Service service = Service.updater("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+            .setFriendlyName("friendlyName").update();
+
+        System.out.println(service.getFriendlyName());
+    }
+}

--- a/verify/v2/service/update-default/update-default.json.curl
+++ b/verify/v2/service/update-default/update-default.json.curl
@@ -1,0 +1,3 @@
+curl -X POST https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX \
+--data-urlencode "FriendlyName=FriendlyName" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/verification/create-default/create-default.3.x.js
+++ b/verify/v2/verification/create-default/create-default.3.x.js
@@ -1,0 +1,11 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .verifications
+             .create({to: '+14159373912', channel: 'sms'})
+             .then(verification => console.log(verification.sid));

--- a/verify/v2/verification/create-default/create-default.5.x.cs
+++ b/verify/v2/verification/create-default/create-default.5.x.cs
@@ -1,0 +1,27 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2.Service;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var verification = VerificationResource.Create(
+            to: "+14159373912",
+            channel: "sms",
+            pathServiceSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        );
+
+        Console.WriteLine(verification.Sid);
+    }
+}

--- a/verify/v2/verification/create-default/create-default.5.x.php
+++ b/verify/v2/verification/create-default/create-default.5.x.php
@@ -1,0 +1,19 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$verification = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                   ->verifications
+                                   ->create("+14159373912", "sms");
+
+print($verification->sid);

--- a/verify/v2/verification/create-default/create-default.5.x.rb
+++ b/verify/v2/verification/create-default/create-default.5.x.rb
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+verification = @client.verify
+                      .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                      .verifications
+                      .create(to: '+14159373912', channel: 'sms')
+
+puts verification.sid

--- a/verify/v2/verification/create-default/create-default.6.x.py
+++ b/verify/v2/verification/create-default/create-default.6.x.py
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+verification = client.verify \
+                     .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                     .verifications \
+                     .create(to='+14159373912', channel='sms')
+
+print(verification.sid)

--- a/verify/v2/verification/create-default/create-default.7.x.java
+++ b/verify/v2/verification/create-default/create-default.7.x.java
@@ -1,0 +1,22 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.service.Verification;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Verification verification = Verification.creator(
+                "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "+14159373912",
+                "sms")
+            .create();
+
+        System.out.println(verification.getSid());
+    }
+}

--- a/verify/v2/verification/create-default/create-default.json.curl
+++ b/verify/v2/verification/create-default/create-default.json.curl
@@ -1,0 +1,4 @@
+curl -X POST https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications \
+--data-urlencode "To=+14159373912" \
+--data-urlencode "Channel=sms" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/verification/create-default/meta.json
+++ b/verify/v2/verification/create-default/meta.json
@@ -1,0 +1,21 @@
+{
+  "type": "server",
+  "title": "Create Verification",
+  "_definition": {
+    "params": {
+      "required": {
+        "to": "+14159373912",
+        "channel": "sms"
+      },
+      "path": {
+        "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{service_sid}/Verifications",
+    "method": "post",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "verification",
+    "action": "create"
+  }
+}

--- a/verify/v2/verification/create-default/output/create-default.json
+++ b/verify/v2/verification/create-default/output/create-default.json
@@ -1,0 +1,23 @@
+{
+  "sid": "VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+14159373912",
+  "channel": "sms",
+  "status": "pending",
+  "valid": null,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "lookup": {
+    "carrier": {
+      "error_code": null,
+      "name": "Carrier Name",
+      "mobile_country_code": "310",
+      "mobile_network_code": "150",
+      "type": "mobile"
+    }
+  },
+  "amount": null,
+  "payee": null,
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications/VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}

--- a/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.3.x.js
+++ b/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.3.x.js
@@ -1,0 +1,16 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .verifications
+             .create({
+                amount: '€39.99',
+                payee: 'Acme Inc.',
+                to: '+14159373912',
+                channel: 'sms'
+              })
+             .then(verification => console.log(verification.sid));

--- a/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.5.x.cs
+++ b/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.5.x.cs
@@ -1,0 +1,29 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2.Service;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var verification = VerificationResource.Create(
+            amount: "€39.99",
+            payee: "Acme Inc.",
+            to: "+14159373912",
+            channel: "sms",
+            pathServiceSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        );
+
+        Console.WriteLine(verification.Sid);
+    }
+}

--- a/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.5.x.php
+++ b/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.5.x.php
@@ -1,0 +1,25 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$verification = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                   ->verifications
+                                   ->create("+14159373912", // to
+                                            "sms", // channel
+                                            array(
+                                                "amount" => "€39.99",
+                                                "payee" => "Acme Inc."
+                                            )
+                                   );
+
+print($verification->sid);

--- a/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.5.x.rb
+++ b/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.5.x.rb
@@ -1,0 +1,21 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+verification = @client.verify
+                      .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                      .verifications
+                      .create(
+                         amount: '€39.99',
+                         payee: 'Acme Inc.',
+                         to: '+14159373912',
+                         channel: 'sms'
+                       )
+
+puts verification.sid

--- a/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.6.x.py
+++ b/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.6.x.py
@@ -1,0 +1,21 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+verification = client.verify \
+                     .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                     .verifications \
+                     .create(
+                          amount='€39.99',
+                          payee='Acme Inc.',
+                          to='+14159373912',
+                          channel='sms'
+                      )
+
+print(verification.sid)

--- a/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.7.x.java
+++ b/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.7.x.java
@@ -1,0 +1,22 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.service.Verification;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Verification verification = Verification.creator(
+                "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "+14159373912",
+                "sms")
+            .setAmount("€39.99").setPayee("Acme Inc.").create();
+
+        System.out.println(verification.getSid());
+    }
+}

--- a/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.json.curl
+++ b/verify/v2/verification/create-psd2_verification_check/create-psd2_verification_check.json.curl
@@ -1,0 +1,6 @@
+curl -X POST https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications \
+--data-urlencode "Amount=€39.99" \
+--data-urlencode "Payee=Acme Inc." \
+--data-urlencode "To=+14159373912" \
+--data-urlencode "Channel=sms" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/verification/create-psd2_verification_check/meta.json
+++ b/verify/v2/verification/create-psd2_verification_check/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Start a PSD2 Verification",
+  "type": "server",
+  "transaction_name": "psd2_verification",
+  "_definition": {
+    "params": {
+      "required": {
+        "amount": "\u20ac39.99",
+        "payee": "Acme Inc.",
+        "to": "+14159373912",
+        "channel": "sms"
+      },
+      "path": {
+        "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{service_sid}/Verifications",
+    "method": "post",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "verification",
+    "action": "create"
+  }
+}

--- a/verify/v2/verification/create-psd2_verification_check/output/create-psd2_verification_check.json
+++ b/verify/v2/verification/create-psd2_verification_check/output/create-psd2_verification_check.json
@@ -1,0 +1,23 @@
+{
+  "sid": "VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+14159373912",
+  "channel": "sms",
+  "status": "pending",
+  "valid": null,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "lookup": {
+    "carrier": {
+      "error_code": null,
+      "name": "Carrier Name",
+      "mobile_country_code": "310",
+      "mobile_network_code": "150",
+      "type": "mobile"
+    }
+  },
+  "amount": "€39.99",
+  "payee": "Acme Inc.",
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications/VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}

--- a/verify/v2/verification/fetch-default/fetch-default.3.x.js
+++ b/verify/v2/verification/fetch-default/fetch-default.3.x.js
@@ -1,0 +1,11 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .verifications('sid')
+             .fetch()
+             .then(verification => console.log(verification.to));

--- a/verify/v2/verification/fetch-default/fetch-default.5.x.cs
+++ b/verify/v2/verification/fetch-default/fetch-default.5.x.cs
@@ -1,0 +1,26 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2.Service;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var verification = VerificationResource.Fetch(
+            pathServiceSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            pathSid: "pathSid"
+        );
+
+        Console.WriteLine(verification.To);
+    }
+}

--- a/verify/v2/verification/fetch-default/fetch-default.5.x.php
+++ b/verify/v2/verification/fetch-default/fetch-default.5.x.php
@@ -1,0 +1,19 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$verification = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                   ->verifications("sid")
+                                   ->fetch();
+
+print($verification->to);

--- a/verify/v2/verification/fetch-default/fetch-default.5.x.rb
+++ b/verify/v2/verification/fetch-default/fetch-default.5.x.rb
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+verification = @client.verify
+                      .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                      .verifications('sid')
+                      .fetch
+
+puts verification.to

--- a/verify/v2/verification/fetch-default/fetch-default.6.x.py
+++ b/verify/v2/verification/fetch-default/fetch-default.6.x.py
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+verification = client.verify \
+                     .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                     .verifications('sid') \
+                     .fetch()
+
+print(verification.to)

--- a/verify/v2/verification/fetch-default/fetch-default.7.x.java
+++ b/verify/v2/verification/fetch-default/fetch-default.7.x.java
@@ -1,0 +1,21 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.service.Verification;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Verification verification = Verification.fetcher(
+                "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "pathSid")
+            .fetch();
+
+        System.out.println(verification.getTo());
+    }
+}

--- a/verify/v2/verification/fetch-default/fetch-default.json.curl
+++ b/verify/v2/verification/fetch-default/fetch-default.json.curl
@@ -1,0 +1,2 @@
+curl -X GET 'https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications/Sid' \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/verification/fetch-default/meta.json
+++ b/verify/v2/verification/fetch-default/meta.json
@@ -1,0 +1,19 @@
+{
+  "type": "server",
+  "title": "Fetch Verification",
+  "_definition": {
+    "params": {
+      "required": {},
+      "path": {
+        "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "sid": "sid"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{service_sid}/Verifications/{sid}",
+    "method": "get",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "verification",
+    "action": "fetch"
+  }
+}

--- a/verify/v2/verification/fetch-default/output/fetch-default.json
+++ b/verify/v2/verification/fetch-default/output/fetch-default.json
@@ -1,0 +1,23 @@
+{
+  "sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+14159373912",
+  "channel": "sms",
+  "status": "pending",
+  "valid": null,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "lookup": {
+    "carrier": {
+      "error_code": null,
+      "name": "Carrier Name",
+      "mobile_country_code": "310",
+      "mobile_network_code": "150",
+      "type": "mobile"
+    }
+  },
+  "amount": "$29.99",
+  "payee": "Acme",
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications/VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}

--- a/verify/v2/verification/update-default/meta.json
+++ b/verify/v2/verification/update-default/meta.json
@@ -1,0 +1,21 @@
+{
+  "type": "server",
+  "title": "Update Verification",
+  "_definition": {
+    "params": {
+      "required": {
+        "status": "canceled"
+      },
+      "path": {
+        "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "sid": "sid"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{service_sid}/Verifications/{sid}",
+    "method": "post",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "verification",
+    "action": "update"
+  }
+}

--- a/verify/v2/verification/update-default/output/update-default.json
+++ b/verify/v2/verification/update-default/output/update-default.json
@@ -1,0 +1,23 @@
+{
+  "sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+14159373912",
+  "channel": "sms",
+  "status": "canceled",
+  "valid": null,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z",
+  "lookup": {
+    "carrier": {
+      "error_code": null,
+      "name": "Carrier Name",
+      "mobile_country_code": "310",
+      "mobile_network_code": "150",
+      "type": "mobile"
+    }
+  },
+  "amount": "$29.99",
+  "payee": "Acme",
+  "url": "https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications/VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}

--- a/verify/v2/verification/update-default/update-default.3.x.js
+++ b/verify/v2/verification/update-default/update-default.3.x.js
@@ -1,0 +1,11 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .verifications('sid')
+             .update({status: 'canceled'})
+             .then(verification => console.log(verification.to));

--- a/verify/v2/verification/update-default/update-default.5.x.cs
+++ b/verify/v2/verification/update-default/update-default.5.x.cs
@@ -1,0 +1,27 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2.Service;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var verification = VerificationResource.Update(
+            status: VerificationResource.StatusEnum.Canceled,
+            pathServiceSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            pathSid: "pathSid"
+        );
+
+        Console.WriteLine(verification.To);
+    }
+}

--- a/verify/v2/verification/update-default/update-default.5.x.php
+++ b/verify/v2/verification/update-default/update-default.5.x.php
@@ -1,0 +1,19 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$verification = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                   ->verifications("sid")
+                                   ->update("canceled");
+
+print($verification->to);

--- a/verify/v2/verification/update-default/update-default.5.x.rb
+++ b/verify/v2/verification/update-default/update-default.5.x.rb
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+verification = @client.verify
+                      .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                      .verifications('sid')
+                      .update(status: 'canceled')
+
+puts verification.to

--- a/verify/v2/verification/update-default/update-default.6.x.py
+++ b/verify/v2/verification/update-default/update-default.6.x.py
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+verification = client.verify \
+                     .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                     .verifications('sid') \
+                     .update(status='canceled')
+
+print(verification.to)

--- a/verify/v2/verification/update-default/update-default.7.x.java
+++ b/verify/v2/verification/update-default/update-default.7.x.java
@@ -1,0 +1,22 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.service.Verification;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        Verification verification = Verification.updater(
+                "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "pathSid",
+                Verification.Status.CANCELED)
+            .update();
+
+        System.out.println(verification.getTo());
+    }
+}

--- a/verify/v2/verification/update-default/update-default.json.curl
+++ b/verify/v2/verification/update-default/update-default.json.curl
@@ -1,0 +1,3 @@
+curl -X POST https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Verifications/Sid \
+--data-urlencode "Status=canceled" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/verification_check/create-default/create-default.3.x.js
+++ b/verify/v2/verification_check/create-default/create-default.3.x.js
@@ -1,0 +1,11 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .verificationChecks
+             .create({to: '+14159373912', code: '1234'})
+             .then(verification_check => console.log(verification_check.sid));

--- a/verify/v2/verification_check/create-default/create-default.5.x.cs
+++ b/verify/v2/verification_check/create-default/create-default.5.x.cs
@@ -1,0 +1,27 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2.Service;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var verificationCheck = VerificationCheckResource.Create(
+            to: "+14159373912",
+            code: "1234",
+            pathServiceSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        );
+
+        Console.WriteLine(verificationCheck.Sid);
+    }
+}

--- a/verify/v2/verification_check/create-default/create-default.5.x.php
+++ b/verify/v2/verification_check/create-default/create-default.5.x.php
@@ -1,0 +1,21 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$verification_check = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                         ->verificationChecks
+                                         ->create("1234", // code
+                                                  array("to" => "+14159373912")
+                                         );
+
+print($verification_check->sid);

--- a/verify/v2/verification_check/create-default/create-default.5.x.rb
+++ b/verify/v2/verification_check/create-default/create-default.5.x.rb
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+verification_check = @client.verify
+                            .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                            .verification_checks
+                            .create(to: '+14159373912', code: '1234')
+
+puts verification_check.sid

--- a/verify/v2/verification_check/create-default/create-default.6.x.py
+++ b/verify/v2/verification_check/create-default/create-default.6.x.py
@@ -1,0 +1,16 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+verification_check = client.verify \
+                           .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                           .verification_checks \
+                           .create(to='+14159373912', code='1234')
+
+print(verification_check.sid)

--- a/verify/v2/verification_check/create-default/create-default.7.x.java
+++ b/verify/v2/verification_check/create-default/create-default.7.x.java
@@ -1,0 +1,21 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.service.VerificationCheck;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        VerificationCheck verificationCheck = VerificationCheck.creator(
+                "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "1234")
+            .setTo("+14159373912").create();
+
+        System.out.println(verificationCheck.getSid());
+    }
+}

--- a/verify/v2/verification_check/create-default/create-default.json.curl
+++ b/verify/v2/verification_check/create-default/create-default.json.curl
@@ -1,0 +1,4 @@
+curl -X POST https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck \
+--data-urlencode "To=+14159373912" \
+--data-urlencode "Code=1234" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/verification_check/create-default/meta.json
+++ b/verify/v2/verification_check/create-default/meta.json
@@ -1,0 +1,21 @@
+{
+  "type": "server",
+  "title": "Create Verification Check",
+  "_definition": {
+    "params": {
+      "required": {
+        "to": "+14159373912",
+        "code": "1234"
+      },
+      "path": {
+        "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{service_sid}/VerificationCheck",
+    "method": "post",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "verification_check",
+    "action": "create"
+  }
+}

--- a/verify/v2/verification_check/create-default/output/create-default.json
+++ b/verify/v2/verification_check/create-default/output/create-default.json
@@ -1,0 +1,13 @@
+{
+  "sid": "VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+14159373912",
+  "channel": "sms",
+  "status": "approved",
+  "valid": false,
+  "amount": null,
+  "payee": null,
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z"
+}

--- a/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.3.x.js
+++ b/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.3.x.js
@@ -1,0 +1,16 @@
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+const accountSid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+const authToken = 'your_auth_token';
+const client = require('twilio')(accountSid, authToken);
+
+client.verify.services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+             .verificationChecks
+             .create({
+                to: '+14159373912',
+                amount: '€39.99',
+                payee: 'Acme Inc.',
+                code: '1234'
+              })
+             .then(verification_check => console.log(verification_check.sid));

--- a/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.5.x.cs
+++ b/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.5.x.cs
@@ -1,0 +1,29 @@
+// Install the C# / .NET helper library from twilio.com/docs/csharp/install
+
+using System;
+using Twilio;
+using Twilio.Rest.Verify.V2.Service;
+
+
+class Program 
+{
+    static void Main(string[] args)
+    {
+        // Find your Account Sid and Token at twilio.com/console
+        // DANGER! This is insecure. See http://twil.io/secure
+        const string accountSid = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+        const string authToken = "your_auth_token";
+
+        TwilioClient.Init(accountSid, authToken);
+
+        var verificationCheck = VerificationCheckResource.Create(
+            to: "+14159373912",
+            amount: "€39.99",
+            payee: "Acme Inc.",
+            code: "1234",
+            pathServiceSid: "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        );
+
+        Console.WriteLine(verificationCheck.Sid);
+    }
+}

--- a/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.5.x.php
+++ b/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.5.x.php
@@ -1,0 +1,25 @@
+<?php
+
+// Update the path below to your autoload.php,
+// see https://getcomposer.org/doc/01-basic-usage.md
+require_once '/path/to/vendor/autoload.php';
+
+use Twilio\Rest\Client;
+
+// Find your Account Sid and Auth Token at twilio.com/console
+// DANGER! This is insecure. See http://twil.io/secure
+$sid    = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+$token  = "your_auth_token";
+$twilio = new Client($sid, $token);
+
+$verification_check = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                         ->verificationChecks
+                                         ->create("1234", // code
+                                                  array(
+                                                      "to" => "+14159373912",
+                                                      "amount" => "€39.99",
+                                                      "payee" => "Acme Inc."
+                                                  )
+                                         );
+
+print($verification_check->sid);

--- a/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.5.x.rb
+++ b/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.5.x.rb
@@ -1,0 +1,21 @@
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+@client = Twilio::REST::Client.new(account_sid, auth_token)
+
+verification_check = @client.verify
+                            .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+                            .verification_checks
+                            .create(
+                               to: '+14159373912',
+                               amount: '€39.99',
+                               payee: 'Acme Inc.',
+                               code: '1234'
+                             )
+
+puts verification_check.sid

--- a/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.6.x.py
+++ b/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.6.x.py
@@ -1,0 +1,21 @@
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+
+
+# Your Account Sid and Auth Token from twilio.com/console
+# DANGER! This is insecure. See http://twil.io/secure
+account_sid = 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+auth_token = 'your_auth_token'
+client = Client(account_sid, auth_token)
+
+verification_check = client.verify \
+                           .services('VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX') \
+                           .verification_checks \
+                           .create(
+                                to='+14159373912',
+                                amount='€39.99',
+                                payee='Acme Inc.',
+                                code='1234'
+                            )
+
+print(verification_check.sid)

--- a/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.7.x.java
+++ b/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.7.x.java
@@ -1,0 +1,24 @@
+// Install the Java helper library from twilio.com/docs/java/install
+
+import com.twilio.Twilio;
+import com.twilio.rest.verify.v2.service.VerificationCheck;
+
+public class Example {
+    // Find your Account Sid and Token at twilio.com/console
+    // DANGER! This is insecure. See http://twil.io/secure
+    public static final String ACCOUNT_SID = "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+    public static final String AUTH_TOKEN = "your_auth_token";
+
+    public static void main(String[] args) {
+        Twilio.init(ACCOUNT_SID, AUTH_TOKEN);
+        VerificationCheck verificationCheck = VerificationCheck.creator(
+                "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "1234")
+            .setTo("+14159373912")
+            .setAmount("€39.99")
+            .setPayee("Acme Inc.")
+            .create();
+
+        System.out.println(verificationCheck.getSid());
+    }
+}

--- a/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.json.curl
+++ b/verify/v2/verification_check/create-psd2_verification_check/create-psd2_verification_check.json.curl
@@ -1,0 +1,6 @@
+curl -X POST https://verify.twilio.com/v2/Services/VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/VerificationCheck \
+--data-urlencode "To=+14159373912" \
+--data-urlencode "Amount=€39.99" \
+--data-urlencode "Payee=Acme Inc." \
+--data-urlencode "Code=1234" \
+-u ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:your_auth_token

--- a/verify/v2/verification_check/create-psd2_verification_check/meta.json
+++ b/verify/v2/verification_check/create-psd2_verification_check/meta.json
@@ -1,0 +1,24 @@
+{
+  "title": "Complete a PSD2 Verification",
+  "type": "server",
+  "transaction_name": "psd2_verification_checks",
+  "_definition": {
+    "params": {
+      "required": {
+        "to": "+14159373912",
+        "amount": "\u20ac39.99",
+        "payee": "Acme Inc.",
+        "code": "1234"
+      },
+      "path": {
+        "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      }
+    },
+    "location": "https://verify.twilio.com/v2/Services/{service_sid}/VerificationCheck",
+    "method": "post",
+    "domain": "verify",
+    "version": "v2",
+    "resource": "verification_check",
+    "action": "create"
+  }
+}

--- a/verify/v2/verification_check/create-psd2_verification_check/output/create-psd2_verification_check.json
+++ b/verify/v2/verification_check/create-psd2_verification_check/output/create-psd2_verification_check.json
@@ -1,0 +1,13 @@
+{
+  "sid": "VEXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "service_sid": "VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "to": "+14159373912",
+  "channel": "sms",
+  "status": "approved",
+  "valid": false,
+  "amount": "€39.99",
+  "payee": "Acme Inc.",
+  "date_created": "2015-07-30T20:00:00Z",
+  "date_updated": "2015-07-30T20:00:00Z"
+}


### PR DESCRIPTION
Also added the default snippets, doesn't look like those ever got generated when we switched to `v2`.

Added updates to the "FriendlyName", "Code", and "To" values. i.e. `"To='to'"` is now `"To=+14159373912"`